### PR TITLE
fix: address circular reference traversal slowdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Available options:
   Don't include `writeOnly` object properties
   - **quiet** - `boolean`
   Don't log console warning messages
+  - **maxSampleDepth** - `number`
+    Max depth sampler should traverse
 - **doc** - the whole schema where the schema is taken from. Might be useful when the `schema` passed is only a portion of the whole schema and $refs aren't resected. **doc** must not contain any external references
 
 ## Example

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -16,11 +16,10 @@ export function clearCache() {
 export function traverse(schema, options, doc, context) {
   // checking circular JS references by checking context
   // because context is passed only when traversing through nested objects happens
-  if (context) {
-    if (seenSchemasStack.includes(schema)) return getResultForCircular(inferType(schema));
-    seenSchemasStack.push(schema);
-  }
 
+  if (seenSchemasStack.includes(schema))
+    return getResultForCircular(inferType(schema));
+  seenSchemasStack.push(schema);
 
   if (context && context.depth > options.maxSampleDepth) {
     popSchemaStack(seenSchemasStack, context);

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -14,13 +14,11 @@ export function clearCache() {
 }
 
 export function traverse(schema, options, doc, context) {
-  // checking circular JS references by checking context
-  // because context is passed only when traversing through nested objects happens
-
   if (seenSchemasStack.includes(schema))
     return getResultForCircular(inferType(schema));
   seenSchemasStack.push(schema);
 
+  //context is passed only when traversing through nested objects happens
   if (context && context.depth > options.maxSampleDepth) {
     popSchemaStack(seenSchemasStack, context);
     return getResultForCircular(inferType(schema));

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,6 +5,7 @@ export interface Options {
   readonly skipReadOnly?: boolean;
   readonly skipWriteOnly?: boolean;
   readonly quiet?: boolean;
+  readonly maxSampleDepth?: number;
 }
 
 export function sample(schema: JSONSchema7, options?: Options, document?: object): unknown;


### PR DESCRIPTION
Related to #[7923](https://app.zenhub.com/workspaces/-team-pierogi-platoon-610871b8d6e5310013071b72/issues/stoplightio/platform-internal/7923)

Will affect #[1770](https://github.com/stoplightio/elements/pull/1770)

- Exposes `maxSampleDepth` as prop to `sample()`
- Removes check for context before looking for circular references